### PR TITLE
add -quick flag to copy directly from module cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rogpeppe/gohack
 
 require (
-	github.com/kr/pretty v0.1.0 // indirect
 	golang.org/x/tools v0.0.0-20180803180156-3c07937fe18c
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/errgo.v2 v2.0.0-20170712173524-1404b2ffbca4
+	gopkg.in/errgo.v2 v2.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,5 +7,5 @@ golang.org/x/tools v0.0.0-20180803180156-3c07937fe18c h1:Z6Xcg33osoOLCiz/EFPHedK
 golang.org/x/tools v0.0.0-20180803180156-3c07937fe18c/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/errgo.v2 v2.0.0-20170712173524-1404b2ffbca4 h1:0hlFZ0xRCsJWzb0XLA/4d/8FhV5Apv49DK8266TAOi0=
-gopkg.in/errgo.v2 v2.0.0-20170712173524-1404b2ffbca4/go.mod h1:e2+3YDPGA8XJ8Lk+bKAvy+3jAR1cSuuG8+hJ3GeqXI8=
+gopkg.in/errgo.v2 v2.0.1 h1:CgqZXIkG0gbG2ftc+1BN2aSjFD4py1iAxxJZheiGFes=
+gopkg.in/errgo.v2 v2.0.1/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/internal/dirhash/hash.go
+++ b/internal/dirhash/hash.go
@@ -1,0 +1,103 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package dirhash defines hashes over directory trees.
+package dirhash
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var DefaultHash = Hash1
+
+type Hash func(files []string, open func(string) (io.ReadCloser, error)) (string, error)
+
+func Hash1(files []string, open func(string) (io.ReadCloser, error)) (string, error) {
+	h := sha256.New()
+	files = append([]string(nil), files...)
+	sort.Strings(files)
+	for _, file := range files {
+		if strings.Contains(file, "\n") {
+			return "", errors.New("filenames with newlines are not supported")
+		}
+		r, err := open(file)
+		if err != nil {
+			return "", err
+		}
+		hf := sha256.New()
+		_, err = io.Copy(hf, r)
+		r.Close()
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%x  %s\n", hf.Sum(nil), file)
+	}
+	return "h1:" + base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}
+
+func HashDir(dir, prefix string, hash Hash) (string, error) {
+	files, err := DirFiles(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	osOpen := func(name string) (io.ReadCloser, error) {
+		return os.Open(filepath.Join(dir, strings.TrimPrefix(name, prefix)))
+	}
+	return hash(files, osOpen)
+}
+
+func DirFiles(dir, prefix string) ([]string, error) {
+	var files []string
+	dir = filepath.Clean(dir)
+	err := filepath.Walk(dir, func(file string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel := file
+		if dir != "." {
+			rel = file[len(dir)+1:]
+		}
+		f := filepath.Join(prefix, rel)
+		files = append(files, filepath.ToSlash(f))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func HashZip(zipfile string, hash Hash) (string, error) {
+	z, err := zip.OpenReader(zipfile)
+	if err != nil {
+		return "", err
+	}
+	defer z.Close()
+	var files []string
+	zfiles := make(map[string]*zip.File)
+	for _, file := range z.File {
+		files = append(files, file.Name)
+		zfiles[file.Name] = file
+	}
+	zipOpen := func(name string) (io.ReadCloser, error) {
+		f := zfiles[name]
+		if f == nil {
+			return nil, fmt.Errorf("file %q not found in zip", name) // should never happen
+		}
+		return f.Open()
+	}
+	return hash(files, zipOpen)
+}

--- a/internal/dirhash/hash_test.go
+++ b/internal/dirhash/hash_test.go
@@ -1,0 +1,135 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dirhash
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func h(s string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(s)))
+}
+
+func htop(k string, s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return k + ":" + base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func TestHash1(t *testing.T) {
+	files := []string{"xyz", "abc"}
+	open := func(name string) (io.ReadCloser, error) {
+		return ioutil.NopCloser(strings.NewReader("data for " + name)), nil
+	}
+	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "abc", h("data for xyz"), "xyz"))
+	out, err := Hash1(files, open)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != want {
+		t.Errorf("Hash1(...) = %s, want %s", out, want)
+	}
+
+	_, err = Hash1([]string{"xyz", "a\nbc"}, open)
+	if err == nil {
+		t.Error("Hash1: expected error on newline in filenames")
+	}
+}
+
+func TestHashDir(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dirhash-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "prefix/abc", h("data for xyz"), "prefix/xyz"))
+	out, err := HashDir(dir, "prefix", Hash1)
+	if err != nil {
+		t.Fatalf("HashDir: %v", err)
+	}
+	if out != want {
+		t.Errorf("HashDir(...) = %s, want %s", out, want)
+	}
+}
+
+func TestHashZip(t *testing.T) {
+	f, err := ioutil.TempFile("", "dirhash-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	z := zip.NewWriter(f)
+	w, err := z.Create("prefix/xyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte("data for xyz"))
+	w, err = z.Create("prefix/abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte("data for abc"))
+	if err := z.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := htop("h1", fmt.Sprintf("%s  %s\n%s  %s\n", h("data for abc"), "prefix/abc", h("data for xyz"), "prefix/xyz"))
+	out, err := HashZip(f.Name(), Hash1)
+	if err != nil {
+		t.Fatalf("HashDir: %v", err)
+	}
+	if out != want {
+		t.Errorf("HashDir(...) = %s, want %s", out, want)
+	}
+}
+
+func TestDirFiles(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dirfiles-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	if err := ioutil.WriteFile(filepath.Join(dir, "xyz"), []byte("data for xyz"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "abc"), []byte("data for abc"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0777); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "subdir", "xyz"), []byte("data for subdir xyz"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	prefix := "foo/bar@v2.3.4"
+	out, err := DirFiles(dir, prefix)
+	if err != nil {
+		t.Fatalf("DirFiles: %v", err)
+	}
+	for _, file := range out {
+		if !strings.HasPrefix(file, prefix) {
+			t.Errorf("Dir file = %s, want prefix %s", file, prefix)
+		}
+	}
+}


### PR DESCRIPTION
This means we can gohack any module that's in the cache
without needing to find VCS info.

In a subsequent PR, we'll remove the `-quick` flag and
make it the default; the current behaviour will be accessed through
a `-vcs` flag.