### PR TITLE
gohack undo: restore old replace comment correctly

### DIFF
--- a/cmdundo.go
+++ b/cmdundo.go
@@ -74,14 +74,17 @@ func cmdUndo1(modules []string) error {
 		prevReplace := splitWasComment(comments.Suffix[0].Token)
 		if prevReplace != nil && prevReplace.Old.Path == r.Old.Path {
 			// We're popping the old replace statement.
-			if !r.Syntax.InBlock {
-				// When we're not in a block, we don't need the "replace" token.
+			if r.Syntax.InBlock {
+				// When we're in a block, we don't need the "replace" token.
 				prevReplace.Syntax.Token = prevReplace.Syntax.Token[1:]
 			}
 			// Preserve any before and after comments.
 			prevReplace.Syntax.Before = r.Syntax.Before
 			prevReplace.Syntax.After = r.Syntax.After
-			*r = *prevReplace
+			r.Old = prevReplace.Old
+			r.New = prevReplace.New
+			r.Syntax.Comments.Suffix = prevReplace.Syntax.Comments.Suffix
+			r.Syntax.Token = prevReplace.Syntax.Token
 		} else {
 			// It's not a "was" comment. Just remove it (after this loop so we don't
 			// interfere with the current range statement).

--- a/testdata/undo-hack-inblock.txt
+++ b/testdata/undo-hack-inblock.txt
@@ -1,0 +1,29 @@
+cd repo
+gohack undo
+stdout 'dropped gopkg.in/errgo.v2'
+
+grep '^\tgopkg.in/errgo.v2 => github.com/rogpeppe/test2/arble v0.0.0-20181008213029-f6022c873160$' go.mod
+
+-- repo/main.go --
+package main
+import _ "gopkg.in/errgo.v2"
+
+-- repo/go.mod --
+module example.com/repo
+
+require (
+	gopkg.in/errgo.v2 v2.1.0
+	rsc.io/sampler v1.3.0
+)
+
+replace (
+	rsc.io/sampler v1.3.0 => rsc.io/sampler v1.2.1
+	gopkg.in/errgo.v2 => ../foo // was gopkg.in/errgo.v2 => github.com/rogpeppe/test2/arble v0.0.0-20181008213029-f6022c873160
+)
+
+-- foo/foo.go --
+package foo
+
+-- foo/go.mod --
+module example.com/foo
+

--- a/testdata/undo-hack.txt
+++ b/testdata/undo-hack.txt
@@ -1,0 +1,22 @@
+cd repo
+gohack undo
+stdout 'dropped gopkg.in/errgo.v2'
+
+grep '^replace gopkg.in/errgo.v2 => github.com/rogpeppe/test2/arble v0.0.0-20181008213029-f6022c873160$' go.mod
+
+-- repo/main.go --
+package main
+import _ "gopkg.in/errgo.v2"
+
+-- repo/go.mod --
+module example.com/repo
+
+require gopkg.in/errgo.v2 v2.1.0
+
+replace gopkg.in/errgo.v2 => ../foo // was gopkg.in/errgo.v2 => github.com/rogpeppe/test2/arble v0.0.0-20181008213029-f6022c873160
+
+-- foo/foo.go --
+package foo
+
+-- foo/go.mod --
+module example.com/foo


### PR DESCRIPTION
When we did `gohack undo`, we were not keeping the old comment.
Also, we were wrongly omitting the "replace" token, which led
to invalid go.mod syntax being produced.