### PR TITLE
Allow relative paths in GOHACK env var

### DIFF
--- a/mod.go
+++ b/mod.go
@@ -112,9 +112,18 @@ func getVCSInfoForModule(m *listModule) (*moduleVCSInfo, error) {
 // used for storing the module with the given path.
 func moduleDir(module string) string {
 	// TODO decide what color this bikeshed should be.
-	d := os.Getenv("GOHACK")
+	d := filepath.FromSlash(os.Getenv("GOHACK"))
 	if d == "" {
 		d = filepath.Join(os.Getenv("HOME"), "gohack")
 	}
-	return filepath.Join(d, filepath.FromSlash(module))
+
+	return join(d, filepath.FromSlash(module))
+}
+
+func join(ps ...string) string {
+	res := filepath.Join(ps...)
+	if !filepath.IsAbs(res) && res[0] != '.' {
+		res = "." + string(os.PathSeparator) + res
+	}
+	return res
 }

--- a/testdata/get-relative-parent.txt
+++ b/testdata/get-relative-parent.txt
@@ -1,0 +1,29 @@
+cd repo
+go get rsc.io/quote@v1.5.2
+env GOHACK=../gohack/
+gohack get rsc.io/quote
+stdout '^rsc.io/quote => \.\./gohack/rsc.io/quote$'
+! stderr .+
+
+# Check that the replace statement is there.
+grep -count=1 '^replace rsc\.io/quote => \.\./gohack/rsc.io/quote$' go.mod
+
+# Check that the source files have been copied.
+exists ../gohack/rsc.io/quote/quote.go
+
+# Check that we can compile the command OK.
+go install example.com/repo
+
+-- repo/main.go --
+package main
+import (
+	"fmt"
+	"rsc.io/quote"
+)
+
+func main() {
+	fmt.Println(quote.Glass())
+}
+
+-- repo/go.mod --
+module example.com/repo

--- a/testdata/get-relative.txt
+++ b/testdata/get-relative.txt
@@ -1,0 +1,32 @@
+cd repo
+go get rsc.io/quote@v1.5.2
+env GOHACK=.
+gohack get rsc.io/quote
+stdout '^rsc.io/quote => \./rsc.io/quote$'
+! stderr .+
+
+# Check that the replace statement is there.
+grep -count=1 '^replace rsc\.io/quote => \./rsc.io/quote$' go.mod
+
+# Check that the source files have been copied.
+exists ./rsc.io/quote/quote.go
+
+# It should not be a git repository.
+! exists ./rsc.io/quote/.git
+
+# Check that we can compile the command OK.
+go install example.com/repo
+
+-- repo/main.go --
+package main
+import (
+	"fmt"
+	"rsc.io/quote"
+)
+
+func main() {
+	fmt.Println(quote.Glass())
+}
+
+-- repo/go.mod --
+module example.com/repo


### PR DESCRIPTION
 Prior to this change, we were using `filepath.Join()` to derive a
 replacement for the module dir. But this is not enough to
 support relative directories, as `Join()` cleans the resulting path,
 removing any `"./"` prefix (which is needed by the replace drective when
 using a local directory).

 This change adds the `"./"` prefix if the user specified it in the GOHACK
 env var.

 Note that relative parent directory `".."` is not cleaned by
 `filepath.Join()`, so we do not need to cater to this case, and an added
 test proves that this works.

 fixes #44
