### PR TITLE
cmdget: support +incompatible tags with -vcs

### DIFF
--- a/cmdget.go
+++ b/cmdget.go
@@ -276,6 +276,10 @@ func updateModule(info *moduleVCSInfo) error {
 		}
 		isTag = false
 		updateTo = revID
+	} else {
+		// Not a pseudo-version. However, this can still be in the form
+		// of "<validtag>+incompatible", so trim the suffix.
+		updateTo = strings.TrimSuffix(updateTo, "+incompatible")
 	}
 	if err := info.vcs.Update(info.dir, isTag, updateTo); err == nil {
 		fmt.Printf("updated hack version of %s to %s\n", info.module.Path, info.module.Version)

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e
 	gopkg.in/errgo.v2 v2.1.0
 )
+
+go 1.12


### PR DESCRIPTION
Doesn't include a test, because rsc.io/quote doesn't have any
+incompatible version, and I couldn't come up with a clean way to add a
test. In any case, the added code is small.

Fixes #42.