### PR TITLE
do not use go list to find go.mod file

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main1() int {
 		return 2
 	}
 
-	if mf, err := goModInfo(); err == nil {
+	if _, mf, err := goModInfo(); err == nil {
 		mainModFile = mf
 	} else {
 		return errorf("cannot determine main module: %v", err)

--- a/script_test.go
+++ b/script_test.go
@@ -46,7 +46,10 @@ func TestScripts(t *testing.T) {
 	p := testscript.Params{
 		Dir: "testdata",
 		Setup: func(e *testscript.Env) error {
-			e.Vars = append(e.Vars, "GOPROXY="+proxyURL)
+			e.Vars = append(e.Vars,
+				"GOPROXY="+proxyURL,
+				"GONOSUMDB=*",
+			)
 			return nil
 		},
 	}

--- a/testdata/get-no-main-mod.txt
+++ b/testdata/get-no-main-mod.txt
@@ -1,0 +1,2 @@
+! gohack get nothing
+stderr 'cannot find main module: no go.mod file found in any parent directory'

--- a/testdata/undo-not-existent.txt
+++ b/testdata/undo-not-existent.txt
@@ -1,0 +1,29 @@
+cd repo
+go get rsc.io/quote@v1.5.2
+env GOHACK=$WORK/gohack
+gohack get rsc.io/quote
+stdout '^rsc.io/quote => .*/gohack/rsc.io/quote$'
+! stderr .+
+
+exists $GOHACK/rsc.io/quote
+rm $GOHACK/rsc.io/quote
+
+gohack undo
+stdout '^dropped rsc\.io/quote$'
+! stderr .+
+
+-- repo/main.go --
+package main
+import (
+	"fmt"
+	"rsc.io/quote"
+	"rsc.io/sampler"
+)
+
+func main() {
+	sampler.DefaultUserPrefs()
+	fmt.Println(quote.Glass())
+}
+
+-- repo/go.mod --
+module example.com/repo


### PR DESCRIPTION
The go list command fails if the go.mod file isn't well formed (like for
example one of the replace directives refers to a non-existent target).
This can be a problem, so find the go.mod file by looking directly for
it instead.